### PR TITLE
Fix: Error when running migrations for added user columns

### DIFF
--- a/src/database/migrations/20240416071256-users_creation.js
+++ b/src/database/migrations/20240416071256-users_creation.js
@@ -31,17 +31,9 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: true
       },
-      userCoverImage: {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
       gender: {
         type: Sequelize.STRING,
         allowNull: false
-      },
-      userBio:{
-        type: DataTypes.STRING,
-        allowNull: true,
       },
       verified:{
         type: Sequelize.BOOLEAN,


### PR DESCRIPTION
As the added columns are already described in a separate migration, this removes the columns that had also been included in the users-creation migration, preventing the clash when the migrations are run from the beginning. The removed columns had also been defined using DataTypes rather than Sequelize resulting in a ReferenceError when the migrations were run.